### PR TITLE
Move allocation and deallocations out from critical sections

### DIFF
--- a/lockbased/BinarySearchTree.h
+++ b/lockbased/BinarySearchTree.h
@@ -32,33 +32,35 @@ class BinarySearchTree {
   BinarySearchTree() : root(nullptr) {};
 
   void insert(const int value) {
-    std::lock_guard<std::recursive_mutex> lock(bst_lock);
     Node *new_node = new Node();
     new_node->value = value;
+    {
+      std::lock_guard<std::recursive_mutex> lock(bst_lock);
 
-    if (!root) {
-      root = new_node;
-      return;
-    }
-
-    Node *curr = root;
-    Node *prev = nullptr;
-    node_type type = LEFT;
-
-    while (curr) {
-      prev = curr;
-      if (value < curr->value) {
-        curr = curr->left;
-        type = LEFT;
-      } else {
-        curr = curr->right;
-        type = RIGHT;
+      if (!root) {
+	root = new_node;
+	return;
       }
 
-      if (type == LEFT) {
-        prev->left = new_node;
-      } else {
-        prev->right = new_node;
+      Node *curr = root;
+      Node *prev = nullptr;
+      node_type type = LEFT;
+
+      while (curr) {
+	prev = curr;
+	if (value < curr->value) {
+	  curr = curr->left;
+	  type = LEFT;
+	} else {
+	  curr = curr->right;
+	  type = RIGHT;
+	}
+
+	if (type == LEFT) {
+	  prev->left = new_node;
+	} else {
+	  prev->right = new_node;
+	}
       }
     }
   }

--- a/lockbased/Deque.h
+++ b/lockbased/Deque.h
@@ -40,58 +40,68 @@ class Deque {
 
   // push_left
   void push_front(int const& data) {
-    std::lock_guard<std::mutex> lock(deque_lock);
-    
     Node *new_node = new Node();
     new_node->data = data;
+    {
+      std::lock_guard<std::mutex> lock(deque_lock);
     
-    new_node->next = head->next;
-    new_node->prev = head;
+      new_node->next = head->next;
+      new_node->prev = head;
 
-    head->next->prev = new_node;
-    head->next = new_node;
+      head->next->prev = new_node;
+      head->next = new_node;
+    }
   }
 
   // push_right
   void push_back(int const& data) {
-    std::lock_guard<std::mutex> lock(deque_lock);
-    
     Node *new_node = new Node();
     new_node->data = data;
+    {
+      std::lock_guard<std::mutex> lock(deque_lock);
 
-    new_node->next = tail;
-    new_node->prev = tail->prev;
+      new_node->next = tail;
+      new_node->prev = tail->prev;
 
-    tail->prev->next = new_node;
-    tail->prev = new_node;
+      tail->prev->next = new_node;
+      tail->prev = new_node;
+    }
   }
 
   // pop_left
   int pop_front() {
-    std::lock_guard<std::mutex> lock(deque_lock);
-    
-    if (head->next != tail) {
-      int data = head->next->data;
-      Node *tmp = head->next;
-      head->next = head->next->next;
-      delete tmp;
-      return data;
+    int data = -1;
+    bool found = false;
+    Node *tmp;
+    {
+      std::lock_guard<std::mutex> lock(deque_lock);
+      if (head->next != tail) {
+	data = head->next->data;
+	tmp = head->next;
+	head->next = head->next->next;
+	found = true;
+      }
     }
-    return -1;
+    if (found) delete tmp;
+    return data;
   }
 
   // pop_right
   int pop_back() {
-    std::lock_guard<std::mutex> lock(deque_lock);
-    
-    if (tail->prev != head) {
-      int data = tail->prev->data;
-      Node *tmp = tail->prev;
-      tail->prev = tail->prev->prev;
-      delete tmp;
-      return data;
+    int data = -1;
+    bool found = false;
+    Node *tmp;
+    {
+      std::lock_guard<std::mutex> lock(deque_lock);
+      if (tail->prev != head) {
+	data = tail->prev->data;
+	tmp = tail->prev;
+	tail->prev = tail->prev->prev;
+	found = true;
+      }
     }
-    return -1;
+    if (found) delete tmp;
+    return data;
   }
 };
 

--- a/lockbased/HashMap.h
+++ b/lockbased/HashMap.h
@@ -95,21 +95,24 @@ class HashMap {
   }
 
   void remove(int const& key) {
-    std::lock_guard<std::mutex> lock(hm_lock);
-    unsigned long index = std::hash<int>{}(key) % TABLE_SIZE;
+    Node *tmp;
+    {
+      std::lock_guard<std::mutex> lock(hm_lock);
+      unsigned long index = std::hash<int>{}(key) % TABLE_SIZE;
 
-    Node *curr = bucket_heads[index]->next;
-    Node *tail = bucket_tails[index];
+      Node *curr = bucket_heads[index]->next;
+      Node *tail = bucket_tails[index];
 
-    while (curr != tail && curr->key != key) {
+      while (curr != tail && curr->key != key) {
         curr = curr->next;
+      }
+
+      if (curr == tail) return;
+
+      tmp = curr;
+      curr->next->prev = curr->prev;
+      curr->prev->next = curr->next;
     }
-
-    if (curr == tail) return;
-
-    Node *tmp = curr;
-    curr->next->prev = curr->prev;
-    curr->prev->next = curr->next;
     delete tmp;
 
     return;


### PR DESCRIPTION
Allocations and Deallocations inside critical sections are not good if they are not needed.
This patch moves out allocations and deallocations from critical sections.

I checked that works, but a double check will be better.
Also, feel free to fix coding style.

Note: I have not checked other versions, it could be worth checking them.